### PR TITLE
localized package install for all-pure integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
         "lockfile:sync": "pnpm install --ignore-workspace",
         "prettify": "prettier . --write",
         "test": "pnpm run test:pretty && pnpm run test:types && pnpm run test:suite && pnpm run test:integ",
-        "test:integ": "pnpm --prefix ./test/all-pure run test",
+        "test:install_deps": "cd ./test/all-pure ; pnpm --ignore-workspace install",
+        "test:integ": "pnpm test:install_deps ; pnpm --prefix test/all-pure run test",
         "test:pretty": "prettier . --check",
-        "test:suite": "node --test  --experimental-test-coverage",
+        "test:suite": "pnpm test:install_deps ; node --test  --experimental-test-coverage",
         "test:types": "pnpm run build:types",
         "testing": "node --test --watch",
         "testing:debug": "node --inspect-brk --test --watch"


### PR DESCRIPTION
installs purity-test deps in its own node_modules/ folder, even in the presence of a helios workspace containing all the other repos.